### PR TITLE
Adding an alert when not finding the Test class

### DIFF
--- a/Aviator/Aviator.m
+++ b/Aviator/Aviator.m
@@ -23,20 +23,27 @@ static Aviator *sharedPlugin;
 
 - (id)init {
     if (self = [super init]) {
-        [self removeConflictingKeyBinding];
-        [self addJumpItem];
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(applicationDidFinishLaunchingNotification:)
+                                                     name:NSApplicationDidFinishLaunchingNotification
+                                                   object:nil];
     }
     return self;
 }
 
-#pragma mark - 
+- (void)applicationDidFinishLaunchingNotification:(NSNotification *)notification {
+    [self removeConflictingKeyBinding];
+    [self addJumpItem];
+}
+
+#pragma mark -
 
 - (void)removeConflictingKeyBinding {
     @try{
         NSMenuItem *fileItem = [[NSApp mainMenu] itemWithTitle:@"File"];
         NSMenuItem *newWindowItem = [[[[[fileItem submenu] itemArray] firstObject] submenu] itemArray][1];
         [newWindowItem setKeyEquivalentModifierMask:NSShiftKeyMask | NSAlternateKeyMask | NSCommandKeyMask];
-    } @catch(NSException *) {}
+    } @catch(NSException *e) { NSLog(@"prevented plugin crash from removeConflictingKeyBinding : %@", e); }
 }
 
 // TODO: Investigate why "Navigate" doesn't work


### PR DESCRIPTION
Delayed menu injection because the Find -> "Jump to Test File" was not appearing 
Add some logs in exception that prevents Xcode from crashing

Added an alert to copy test class name if not found in project :

![screen shot 2015-06-10 at 19 47 47](https://cloud.githubusercontent.com/assets/1105089/8089758/3284e536-0faa-11e5-8c25-f34a181b465a.png)

