### PR TITLE
Fix issue where Aviator jumps to a test helper file e.g "Stub" rather…

### DIFF
--- a/Aviator/TFFFileProvider.m
+++ b/Aviator/TFFFileProvider.m
@@ -17,6 +17,20 @@
     return self;
 }
 
+- (TFFReference *)bestSuitableTestReferenceFromTestReferences:(NSArray<TFFReference *> *) references {
+    
+    [references sortedArrayUsingComparator:^NSComparisonResult(TFFReference *  _Nonnull ref1, TFFReference *  _Nonnull ref2) {
+        if ([ref1.name rangeOfString:@"Test"].location != NSNotFound) {
+            return NSOrderedAscending;
+        }
+        else {
+            return NSOrderedSame;
+        }
+    }];
+    
+    return references.firstObject;
+}
+
 - (TFFFileReferenceCollection *)referenceCollectionForSourceCodeDocument:(IDESourceCodeDocument *)sourceCodeDocument {
     if (sourceCodeDocument) {
         DVTFilePath *filePath = sourceCodeDocument.filePath;
@@ -27,11 +41,13 @@
         TFFReference *sourceRef = nil;
         TFFReference *testRef = nil;
         
+        NSMutableArray *testReferences = [NSMutableArray new];
+        
         NSArray *fileReferences = self.fileReferences;
         for (TFFReference *reference in fileReferences) {
             if ([reference.name rangeOfString:fileName].location != NSNotFound) {
                 if (reference.isTestFile) {
-                    testRef = reference;
+                    [testReferences addObject:reference];
                 } else if (reference.isSourceFile) {
                     sourceRef = reference;
                 } else if (reference.isHeaderFile) {
@@ -39,6 +55,8 @@
                 }
             }
         }
+        
+        testRef = [self bestSuitableTestReferenceFromTestReferences:testReferences];
         
         return [[TFFFileReferenceCollection alloc] initWithHeaderFileReference:headerRef sourceFileReference:sourceRef testFileReference:testRef];
     }

--- a/Aviator/TFFFileProviderTests.m
+++ b/Aviator/TFFFileProviderTests.m
@@ -113,4 +113,15 @@
     [self verifyReferenceCollectionHeader:headerRef1 source:sourceRef1 test:nil];
 }
 
+- (void)testWhenSourceFileExistsWithMultipleMatchingUnitTestFilesThenReturnTestFileWithSuffixTests {
+    TFFReference *headerRef1 = [self headerReferenceWithName:@"StarWars.h"];
+    TFFReference *sourceRef1 = [self sourceReferenceWithName:@"StarWars.m"];
+    TFFReference *testRef1 = [self testReferenceWithName:@"StarWarsTests.m"];
+    TFFReference *testRef2 = [self testReferenceWithName:@"StubStarWars.m"];
+    
+    testObject = [[TFFFileProvider alloc] initWithFileReferences:@[headerRef1, sourceRef1, testRef1, testRef2]];
+    [self setCurrentDocumentAsFile:@"StarWars.m"];
+    [self verifyReferenceCollectionHeader:headerRef1 source:sourceRef1 test:testRef1];
+}
+
 @end


### PR DESCRIPTION
… than jumping to the actual "Tests" file

I came across this issue at work and wasn't able to jump to my test files hence the fix.
Is this worth pulling into your repo? Any suggestions to improve the fix?