### PR TITLE
Pick best matching test file to switch to when test helpers and stubs are present

### DIFF
--- a/Aviator/TFFFileProvider.m
+++ b/Aviator/TFFFileProvider.m
@@ -17,6 +17,20 @@
     return self;
 }
 
+- (TFFReference *)bestSuitableTestReferenceFromTestReferences:(NSArray<TFFReference *> *) references {
+    
+    [references sortedArrayUsingComparator:^NSComparisonResult(TFFReference *  _Nonnull ref1, TFFReference *  _Nonnull ref2) {
+        if ([ref1.name rangeOfString:@"Test"].location != NSNotFound) {
+            return NSOrderedAscending;
+        }
+        else {
+            return NSOrderedSame;
+        }
+    }];
+    
+    return references.firstObject;
+}
+
 - (TFFFileReferenceCollection *)referenceCollectionForSourceCodeDocument:(IDESourceCodeDocument *)sourceCodeDocument {
     if (sourceCodeDocument) {
         DVTFilePath *filePath = sourceCodeDocument.filePath;
@@ -27,11 +41,13 @@
         TFFReference *sourceRef = nil;
         TFFReference *testRef = nil;
         
+        NSMutableArray *testReferences = [NSMutableArray new];
+        
         NSArray *fileReferences = self.fileReferences;
         for (TFFReference *reference in fileReferences) {
             if ([reference.name rangeOfString:fileName].location != NSNotFound) {
                 if (reference.isTestFile) {
-                    testRef = reference;
+                    [testReferences addObject:reference];
                 } else if (reference.isSourceFile) {
                     sourceRef = reference;
                 } else if (reference.isHeaderFile) {
@@ -39,6 +55,8 @@
                 }
             }
         }
+        
+        testRef = [self bestSuitableTestReferenceFromTestReferences:testReferences];
         
         return [[TFFFileReferenceCollection alloc] initWithHeaderFileReference:headerRef sourceFileReference:sourceRef testFileReference:testRef];
     }

--- a/Aviator/TFFFileProviderTests.m
+++ b/Aviator/TFFFileProviderTests.m
@@ -113,15 +113,29 @@
     [self verifyReferenceCollectionHeader:headerRef1 source:sourceRef1 test:nil];
 }
 
-- (void)testWhenSourceFileExistsWithMultipleMatchingUnitTestFilesThenReturnTestFileWithSuffixTests {
+- (void)testWhenSourceFileExistsWithTestHelperAndTestsUnitTestFilesThenReferenceCollectionReturnsTestFileWithSuffixTests {
     TFFReference *headerRef1 = [self headerReferenceWithName:@"StarWars.h"];
     TFFReference *sourceRef1 = [self sourceReferenceWithName:@"StarWars.m"];
-    TFFReference *testRef1 = [self testReferenceWithName:@"StarWarsTests.m"];
-    TFFReference *testRef2 = [self testReferenceWithName:@"StubStarWars.m"];
     
-    testObject = [[TFFFileProvider alloc] initWithFileReferences:@[headerRef1, sourceRef1, testRef1, testRef2]];
+    TFFReference *testHelperTestRef = [self testReferenceWithName:@"StarWarsTestHelper.m"];
+    TFFReference *testsTestRef = [self testReferenceWithName:@"StarWarsTests.m"];
+    
+    testObject = [[TFFFileProvider alloc] initWithFileReferences:@[headerRef1, sourceRef1, testHelperTestRef, testsTestRef]];
     [self setCurrentDocumentAsFile:@"StarWars.m"];
-    [self verifyReferenceCollectionHeader:headerRef1 source:sourceRef1 test:testRef1];
+    [self verifyReferenceCollectionHeader:headerRef1 source:sourceRef1 test:testsTestRef];
+}
+
+- (void)testWhenSourceFileExistsWithMultipleMatchingUnitTestFilesThenReferenceCollectionReturnsTestFileWithSuffixTests {
+    TFFReference *headerRef1 = [self headerReferenceWithName:@"StarWars.h"];
+    TFFReference *sourceRef1 = [self sourceReferenceWithName:@"StarWars.m"];
+    
+    TFFReference *stubTestRef = [self testReferenceWithName:@"StubStarWars.m"];
+    TFFReference *testsTestRef = [self testReferenceWithName:@"StarWarsTests.m"];
+    TFFReference *testHelperTestRef = [self testReferenceWithName:@"StarWarsTestHelper.m"];
+    
+    testObject = [[TFFFileProvider alloc] initWithFileReferences:@[headerRef1, sourceRef1, testHelperTestRef, testsTestRef, stubTestRef]];
+    [self setCurrentDocumentAsFile:@"StarWars.m"];
+    [self verifyReferenceCollectionHeader:headerRef1 source:sourceRef1 test:testsTestRef];
 }
 
 @end

--- a/Aviator/TFFFileProviderTests.m
+++ b/Aviator/TFFFileProviderTests.m
@@ -113,4 +113,15 @@
     [self verifyReferenceCollectionHeader:headerRef1 source:sourceRef1 test:nil];
 }
 
+- (void)testWhenSourceFileExistsWithMultipleMatchingUnitTestFilesThenReturnTestFileWithSuffixTests {
+    TFFReference *headerRef1 = [self headerReferenceWithName:@"StarWars.h"];
+    TFFReference *sourceRef1 = [self sourceReferenceWithName:@"StarWars.m"];
+    TFFReference *testRef1 = [self testReferenceWithName:@"StarWarsTests.m"];
+    TFFReference *testRef2 = [self testReferenceWithName:@"StubStarWars.m"];
+    
+    testObject = [[TFFFileProvider alloc] initWithFileReferences:@[headerRef1, sourceRef1, testRef1, testRef2]];
+    [self setCurrentDocumentAsFile:@"StarWars.m"];
+    [self verifyReferenceCollectionHeader:headerRef1 source:sourceRef1 test:testRef1];
+}
+
 @end


### PR DESCRIPTION
In our codebase at work we use a lot of Stub files that have the same base filename as the source file but are located in the testing target. Depending on their order in the project, Aviator can jump to these Stub files instead of jumping to the Tests file which is annoying.

This fix introduces a ranking for names so that the best matching test file is picked:

1st match: MyClass**Tests**.swift
2nd match: MyClass**Test**Helper.swift
3rd match: MyClassStub.swift

Do you think this fix is worth pulling into your repo?
Any suggestions?

