### PR TITLE
Xcode 8 Support / copy expected test class name

### DIFF
--- a/Aviator.xcodeproj/project.pbxproj
+++ b/Aviator.xcodeproj/project.pbxproj
@@ -84,7 +84,6 @@
 		76ADCE8D19D6F7D20072D2FC /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Aviator/Info.plist; sourceTree = SOURCE_ROOT; };
 		76ADCE8F19D6F7EC0072D2FC /* Aviator.xcscheme */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = Aviator.xcscheme; path = Aviator.xcodeproj/xcshareddata/xcschemes/Aviator.xcscheme; sourceTree = SOURCE_ROOT; };
 		76EA5EA219E0EE38002F84C7 /* TFFFileProviderTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TFFFileProviderTests.m; sourceTree = "<group>"; };
-		76EA5EBA19E0EE40002F84C7 /* Aviator copy-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Aviator copy-Info.plist"; path = "/Users/mrsand1/Development/Aviator/Aviator copy-Info.plist"; sourceTree = "<absolute>"; };
 		76EA5ECA19E0EF6B002F84C7 /* AviatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AviatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		76EA5ECD19E0EF6B002F84C7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -117,7 +116,6 @@
 				76EA5ECB19E0EF6B002F84C7 /* AviatorTests */,
 				76225AC419D6792F00755F57 /* Frameworks */,
 				76225AC319D6792F00755F57 /* Products */,
-				76EA5EBA19E0EE40002F84C7 /* Aviator copy-Info.plist */,
 			);
 			sourceTree = "<group>";
 		};
@@ -271,7 +269,7 @@
 		76225ABA19D6792F00755F57 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0600;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "Type440 LLC";
 				TargetAttributes = {
 					76225AC119D6792F00755F57 = {
@@ -374,14 +372,18 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -412,14 +414,17 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
@@ -443,6 +448,7 @@
 					"-undefined",
 					dynamic_lookup,
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "type440.llc.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = xcplugin;
 			};
@@ -461,6 +467,7 @@
 					"-undefined",
 					dynamic_lookup,
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "type440.llc.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = xcplugin;
 			};
@@ -501,6 +508,7 @@
 					"-undefined",
 					dynamic_lookup,
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "Type440-LLC.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 			};
@@ -538,6 +546,7 @@
 					"-undefined",
 					dynamic_lookup,
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "Type440-LLC.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 			};

--- a/Aviator.xcodeproj/xcshareddata/xcschemes/AviatorTests.xcscheme
+++ b/Aviator.xcodeproj/xcshareddata/xcschemes/AviatorTests.xcscheme
@@ -5,22 +5,6 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
-      <BuildActionEntries>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "76225AC119D6792F00755F57"
-               BuildableName = "Aviator.xcplugin"
-               BlueprintName = "Aviator"
-               ReferencedContainer = "container:Aviator.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
@@ -28,6 +12,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "76EA5EC919E0EF6B002F84C7"
+               BuildableName = "AviatorTests.xctest"
+               BlueprintName = "AviatorTests"
+               ReferencedContainer = "container:Aviator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <AdditionalOptions>
       </AdditionalOptions>
@@ -42,19 +36,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <PathRunnable
-         runnableDebuggingMode = "0"
-         FilePath = "/Applications/Xcode.app">
-      </PathRunnable>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "76225AC119D6792F00755F57"
-            BuildableName = "Aviator.xcplugin"
-            BlueprintName = "Aviator"
-            ReferencedContainer = "container:Aviator.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/Aviator/Aviator.m
+++ b/Aviator/Aviator.m
@@ -33,14 +33,14 @@ static Aviator *sharedPlugin;
     [[NSNotificationCenter defaultCenter] removeObserver:self name:NSApplicationDidFinishLaunchingNotification object:nil];
 }
 
-#pragma mark - 
+#pragma mark -
 
 - (void)removeConflictingKeyBinding {
     @try{
         NSMenuItem *fileItem = [[NSApp mainMenu] itemWithTitle:@"File"];
         NSMenuItem *newWindowItem = [[[[[fileItem submenu] itemArray] firstObject] submenu] itemArray][1];
         [newWindowItem setKeyEquivalentModifierMask:NSShiftKeyMask | NSAlternateKeyMask | NSCommandKeyMask];
-    } @catch(NSException *) {}
+    } @catch(NSException *e) { NSLog(@"prevented plugin crash from removeConflictingKeyBinding : %@", e); }
 }
 
 // TODO: Investigate why "Navigate" doesn't work

--- a/Aviator/Aviator.m
+++ b/Aviator/Aviator.m
@@ -43,7 +43,6 @@ static Aviator *sharedPlugin;
     } @catch(NSException *e) { NSLog(@"prevented plugin crash from removeConflictingKeyBinding : %@", e); }
 }
 
-// TODO: Investigate why "Navigate" doesn't work
 - (void)addJumpItem {
     NSMenuItem *navigateItem = [[NSApp mainMenu] itemWithTitle:@"Find"];
     if (navigateItem) {

--- a/Aviator/Info.plist
+++ b/Aviator/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
-	<string>type440.llc.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Aviator/Info.plist
+++ b/Aviator/Info.plist
@@ -41,6 +41,7 @@
 		<string>7265231C-39B4-402C-89E1-16167C4CC990</string>
 		<string>F41BD31E-2683-44B8-AE7F-5F09E919790E</string>
 		<string>ACA8656B-FEA8-4B6D-8E4A-93F4C95C362C</string>
+		<string>8A66E736-A720-4B3C-92F1-33D9962C69DF</string>
 	</array>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2014 Mark Sands.</string>

--- a/Aviator/Info.plist
+++ b/Aviator/Info.plist
@@ -42,6 +42,7 @@
 		<string>F41BD31E-2683-44B8-AE7F-5F09E919790E</string>
 		<string>ACA8656B-FEA8-4B6D-8E4A-93F4C95C362C</string>
 		<string>8A66E736-A720-4B3C-92F1-33D9962C69DF</string>
+		<string>DA4FDFD8-C509-4D8B-8B55-84A7B66AE701</string>
 	</array>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2014 Mark Sands.</string>

--- a/Aviator/TFFFileProvider.m
+++ b/Aviator/TFFFileProvider.m
@@ -31,13 +31,19 @@
         
         NSArray *fileReferences = self.fileReferences;
         for (TFFReference *reference in fileReferences) {
-            if ([reference.name rangeOfString:fileName].location != NSNotFound) {
+            if( ! [reference isKindOfClass:[TFFFileReference class]] ) {
+                continue;
+            }
+            NSRange range = [reference.name rangeOfString:fileName];
+            if (range.location != NSNotFound) {
                 if (reference.isTestFile) {
                     [testReferences addObject:reference];
-                } else if (reference.isSourceFile) {
-                    sourceRef = reference;
-                } else if (reference.isHeaderFile) {
-                    headerRef = reference;
+                } else if( [reference.name.stringByDeletingPathExtension isEqualToString:fileName] ) {
+                    if (reference.isSourceFile) {
+                        sourceRef = reference;
+                    } else if (reference.isHeaderFile) {
+                        headerRef = reference;
+                    }
                 }
             }
         }
@@ -52,7 +58,7 @@
 
 - (NSString *)fileNameByStrippingExtensionAndLastOccuranceOfTest:(NSString *)fileName {
     NSString *file = [fileName stringByDeletingPathExtension];
-    NSString *strippedFileName = nil;
+    NSString *strippedFileName = file;
     
     if (file.length >= 5) {
         NSRange rangeOfOccurrenceOfTest = [file rangeOfString:@"Test" options:NSCaseInsensitiveSearch range:NSMakeRange(file.length - 5, 5)];

--- a/Aviator/TFFFileProviderTests.m
+++ b/Aviator/TFFFileProviderTests.m
@@ -19,15 +19,13 @@
 
 - (PBXTargetDouble *)testTarget {
     PBXTargetDouble *target = OCMClassMock([PBXTargetDouble class]);
-    BOOL yes = YES;
-    [OCMStub([target _looksLikeUnitTestTarget]) andReturnValue:OCMOCK_VALUE(yes)];
+    [OCMStub([target targetTypeDisplayName]) andReturn:@"Unit Test Bundle"];
     return target;
 }
 
 - (PBXTargetDouble *)aviatorTarget {
     PBXTargetDouble *target = OCMClassMock([PBXTargetDouble class]);
-    BOOL no = NO;
-    [OCMStub([target _looksLikeUnitTestTarget]) andReturnValue:OCMOCK_VALUE(no)];
+    [OCMStub([target targetTypeDisplayName]) andReturn:@"Application"];
     return target;
 }
 
@@ -136,6 +134,23 @@
     testObject = [[TFFFileProvider alloc] initWithFileReferences:@[headerRef1, sourceRef1, testHelperTestRef, testsTestRef, stubTestRef]];
     [self setCurrentDocumentAsFile:@"StarWars.m"];
     [self verifyReferenceCollectionHeader:headerRef1 source:sourceRef1 test:testsTestRef];
+}
+    
+- (void)testReferenceWithNameThenShouldHaveIsTestFileSettedToYES {
+    TFFReference *testRef2 = [self testReferenceWithName:@"StarWarTests.m"];
+    XCTAssertTrue(testRef2.isTestFile);
+}
+
+- (void)testWhenSourceFileExistsWithOtherSuffixesThenShouldOpenCorrectTestFile {
+    TFFReference *headerRef1 = [self headerReferenceWithName:@"StarWars.h"];
+    TFFReference *sourceRef1 = [self sourceReferenceWithName:@"StarWars.m"];
+    TFFReference *headerRef2 = [self headerReferenceWithName:@"StarWarsSpaceShip.h"];
+    TFFReference *sourceRef2 = [self sourceReferenceWithName:@"StarWarsSpaceShip.m"];
+    TFFReference *testRef = [self testReferenceWithName:@"StarWarTests.m"];
+
+    testObject = [[TFFFileProvider alloc] initWithFileReferences:@[headerRef1, sourceRef1, headerRef2, sourceRef2,  testRef]];
+    [self setCurrentDocumentAsFile:@"StarWars.m"];
+    [self verifyReferenceCollectionHeader:headerRef1 source:sourceRef1 test:testRef];
 }
 
 @end

--- a/Aviator/TFFFileProviderTests.m
+++ b/Aviator/TFFFileProviderTests.m
@@ -141,15 +141,25 @@
     XCTAssertTrue(testRef2.isTestFile);
 }
 
-- (void)testWhenSourceFileExistsWithOtherSuffixesThenShouldOpenCorrectTestFile {
+- (void)testWhenSourceFileExistsWithOtherSuffixesThenReferenceCollectionReturnsCorrectTestFile {
     TFFReference *headerRef1 = [self headerReferenceWithName:@"StarWars.h"];
     TFFReference *sourceRef1 = [self sourceReferenceWithName:@"StarWars.m"];
     TFFReference *headerRef2 = [self headerReferenceWithName:@"StarWarsSpaceShip.h"];
     TFFReference *sourceRef2 = [self sourceReferenceWithName:@"StarWarsSpaceShip.m"];
-    TFFReference *testRef = [self testReferenceWithName:@"StarWarTests.m"];
+    TFFReference *testRef = [self testReferenceWithName:@"StarWarsTests.m"];
 
-    testObject = [[TFFFileProvider alloc] initWithFileReferences:@[headerRef1, sourceRef1, headerRef2, sourceRef2,  testRef]];
+    testObject = [[TFFFileProvider alloc] initWithFileReferences:@[headerRef1, sourceRef1, headerRef2, sourceRef2, testRef]];
     [self setCurrentDocumentAsFile:@"StarWars.m"];
+    [self verifyReferenceCollectionHeader:headerRef1 source:sourceRef1 test:testRef];
+}
+
+- (void)testWhenSourceFileExistsWithLessThanFiveCharactersNameThenReferenceCollectionReturnsCorrectTestFile {
+    TFFReference *headerRef1 = [self headerReferenceWithName:@"Star.h"];
+    TFFReference *sourceRef1 = [self sourceReferenceWithName:@"Star.m"];
+    TFFReference *testRef = [self testReferenceWithName:@"StarTests.m"];
+    
+    testObject = [[TFFFileProvider alloc] initWithFileReferences:@[headerRef1, sourceRef1, testRef]];
+    [self setCurrentDocumentAsFile:@"Star.m"];
     [self verifyReferenceCollectionHeader:headerRef1 source:sourceRef1 test:testRef];
 }
 

--- a/Aviator/TFFFileReference.m
+++ b/Aviator/TFFFileReference.m
@@ -26,7 +26,6 @@
         
         for (PBXTarget *target in [targets allObjects]) {
             if( ![[target targetTypeDisplayName] containsString:@"Test"] ) {
-            //if (![target _looksLikeUnitTestTarget]) {
                 _isTestFile = NO;
             }
         }

--- a/Aviator/TFFFileReference.m
+++ b/Aviator/TFFFileReference.m
@@ -32,7 +32,10 @@
         }
         
         if (!self.isTestFile) {
-            if ([self.pbxFileReference.name.pathExtension isEqualToString:@"m"]) {
+            if ([self.pbxFileReference.name.pathExtension isEqualToString:@"m"] ||
+                [self.pbxFileReference.name.pathExtension isEqualToString:@"mm"] ||
+                [self.pbxFileReference.name.pathExtension isEqualToString:@"swift"]
+                ) {
                 _isSourceFile = YES;
             } else {
                 _isHeaderFile = YES;

--- a/Aviator/TFFFileReference.m
+++ b/Aviator/TFFFileReference.m
@@ -25,7 +25,8 @@
         }
         
         for (PBXTarget *target in [targets allObjects]) {
-            if (![target _looksLikeUnitTestTarget]) {
+            if( ![[target targetTypeDisplayName] containsString:@"Test"] ) {
+            //if (![target _looksLikeUnitTestTarget]) {
                 _isTestFile = NO;
             }
         }

--- a/Aviator/TFFFileSwitcher.m
+++ b/Aviator/TFFFileSwitcher.m
@@ -18,8 +18,10 @@
 
 - (void)switchBetweenReferenceCollectionFilesForCurrentSourceDocument:(IDESourceCodeDocument *)sourceCodeDocument {
     @try {
+        NSLog(@"jumping0.............");
         TFFFileReferenceCollection *referenceCollection = [self.fileProvider referenceCollectionForSourceCodeDocument:sourceCodeDocument];
-        
+        NSLog(@"jumping1.............");
+        NSLog(@"jumping from: %@", sourceCodeDocument.filePath);
         NSString *fileName = sourceCodeDocument.filePath.fileURL.lastPathComponent;
         if ([referenceCollection.headerFile.name isEqualToString:fileName] || [referenceCollection.sourceFile.name isEqualToString:fileName]) {
             if( referenceCollection.testFile == nil ) {
@@ -36,12 +38,17 @@
                     [pasteboard setString:testFilename forType:NSStringPboardType];
                 }
             } else {
+                NSLog(@"jumping to test file : %@",referenceCollection.testFile.absolutePath);
+
                 [[self XcodeNavigatorClassSeam] jumpToFileURL:[NSURL fileURLWithPath:referenceCollection.testFile.absolutePath]];
             }
         } else if ([referenceCollection.testFile.name isEqualToString:fileName]) {
             if( referenceCollection.sourceFile.absolutePath ) {
+                NSLog(@"jumping to source file : %@",referenceCollection.sourceFile.absolutePath);
                 [self.XcodeNavigatorClassSeam jumpToFileURL:[NSURL fileURLWithPath:referenceCollection.sourceFile.absolutePath]];
             } else {
+                NSLog(@"jumping to headerFile file : %@",referenceCollection.headerFile.absolutePath);
+
                 [self.XcodeNavigatorClassSeam jumpToFileURL:[NSURL fileURLWithPath:referenceCollection.headerFile.absolutePath]];
             }
         }

--- a/Aviator/TFFFileSwitcher.m
+++ b/Aviator/TFFFileSwitcher.m
@@ -3,7 +3,7 @@
 #import "TFFXcodeDocumentNavigator.h"
 #import "TFFFileProvider.h"
 
-@interface TFFFileSwitcher ()
+@interface TFFFileSwitcher () <NSAlertDelegate>
 @property (nonatomic, readonly) TFFFileProvider *fileProvider;
 @end
 
@@ -23,6 +23,22 @@
         NSString *fileName = sourceCodeDocument.filePath.fileURL.lastPathComponent;
         if ([referenceCollection.headerFile.name isEqualToString:fileName] || [referenceCollection.sourceFile.name isEqualToString:fileName]) {
             [self.XcodeNavigatorClassSeam jumpToFileURL:[NSURL fileURLWithPath:referenceCollection.testFile.absolutePath]];
+            if( referenceCollection.testFile == nil ) {
+                NSString *testFilename = [[fileName stringByDeletingPathExtension] stringByAppendingString:@"Tests"];
+                NSAlert *alert = [[NSAlert alloc]init];
+                [alert setDelegate:self];
+                [alert addButtonWithTitle:@"Copy test class name"];
+                [alert addButtonWithTitle:@"Cancel"];
+                [alert setMessageText:[NSString stringWithFormat:@"Can't find %@ in project, maybe you want to create it ?", testFilename]];
+                long rCode = [alert runModal];
+                if( rCode == NSAlertFirstButtonReturn ) {
+                    NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
+                    [pasteboard declareTypes:[NSArray arrayWithObject:NSStringPboardType] owner:nil];
+                    [pasteboard setString:testFilename forType:NSStringPboardType];
+                }
+            } else {
+                [[self XcodeNavigatorClassSeam] jumpToFileURL:[NSURL fileURLWithPath:referenceCollection.testFile.absolutePath]];
+            }
         } else if ([referenceCollection.testFile.name isEqualToString:fileName]) {
             if( referenceCollection.sourceFile.absolutePath ) {
                 [self.XcodeNavigatorClassSeam jumpToFileURL:[NSURL fileURLWithPath:referenceCollection.sourceFile.absolutePath]];
@@ -30,7 +46,7 @@
                 [self.XcodeNavigatorClassSeam jumpToFileURL:[NSURL fileURLWithPath:referenceCollection.headerFile.absolutePath]];
             }
         }
-    } @catch (NSException *) {}
+    } @catch (NSException *e) { NSLog(@"prevented plugin crash from switchBetweenReferenceCollectionFilesForCurrentSourceDocument : %@", e); }
 }
 
 - (Class)XcodeNavigatorClassSeam {

--- a/Aviator/TFFFileSwitcher.m
+++ b/Aviator/TFFFileSwitcher.m
@@ -22,7 +22,6 @@
         
         NSString *fileName = sourceCodeDocument.filePath.fileURL.lastPathComponent;
         if ([referenceCollection.headerFile.name isEqualToString:fileName] || [referenceCollection.sourceFile.name isEqualToString:fileName]) {
-            [self.XcodeNavigatorClassSeam jumpToFileURL:[NSURL fileURLWithPath:referenceCollection.testFile.absolutePath]];
             if( referenceCollection.testFile == nil ) {
                 NSString *testFilename = [[fileName stringByDeletingPathExtension] stringByAppendingString:@"Tests"];
                 NSAlert *alert = [[NSAlert alloc]init];

--- a/Aviator/TFFFileSwitcherTests.m
+++ b/Aviator/TFFFileSwitcherTests.m
@@ -24,15 +24,13 @@
 
 - (PBXTargetDouble *)testTarget {
     PBXTargetDouble *target = OCMClassMock([PBXTargetDouble class]);
-    BOOL yes = YES;
-    [OCMStub([target _looksLikeUnitTestTarget]) andReturnValue:OCMOCK_VALUE(yes)];
+    [OCMStub([target targetTypeDisplayName]) andReturn:@""];
     return target;
 }
 
 - (PBXTargetDouble *)aviatorTarget {
     PBXTargetDouble *target = OCMClassMock([PBXTargetDouble class]);
-    BOOL no = NO;
-    [OCMStub([target _looksLikeUnitTestTarget]) andReturnValue:OCMOCK_VALUE(no)];
+    [OCMStub([target targetTypeDisplayName]) andReturn:@"Bundle"];
     return target;
 }
 

--- a/Aviator/XCodePrivate.h
+++ b/Aviator/XCodePrivate.h
@@ -86,6 +86,7 @@
 @interface PBXTarget : PBXObject
 - (NSString *)name;
 - (BOOL)_looksLikeUnitTestTarget;
+- (NSString *)targetTypeDisplayName;
 @end
 
 @interface PBXFileType : NSObject

--- a/Aviator/XCodePrivate.h
+++ b/Aviator/XCodePrivate.h
@@ -85,7 +85,6 @@
 
 @interface PBXTarget : PBXObject
 - (NSString *)name;
-- (BOOL)_looksLikeUnitTestTarget;
 - (NSString *)targetTypeDisplayName;
 @end
 

--- a/AviatorTests/FakeXcode.m
+++ b/AviatorTests/FakeXcode.m
@@ -29,7 +29,8 @@
 @end
 @implementation PBXTarget
 - (NSString *)name { return nil; }
-- (BOOL)_looksLikeUnitTestTarget { return NO; }
+// possible values : "Application", "Unit Test Bundle", "Bundle"
+- (NSString *)targetTypeDisplayName { return @"Application"; }
 @end
 
 @implementation PBXContainer

--- a/AviatorTests/Info.plist
+++ b/AviatorTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>Type440-LLC.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
Hi Mark,

Just fixed a crash on xcode8 for your plugin
Two commits because the first adds the feature : I want to copy test class name when no test file are found

To make plugin work with xcode8 on Sierra, i run this script : 

```
#!/bin/bash

if [ $# -lt 1 ] ; then
        echo "usage : $(basename $0) /Application/Xcode.app";
        exit -1
fi

XCODE_APP_PATH=$1

/usr/bin/codesign --force --sign "Mac Developer" --timestamp=none /Applications/Xcode.app
/usr/bin/codesign --force --sign "Mac Developer" --timestamp=none /Applications/Xcode.app/Contents/PlugIns/IDEDocViewer.ideplugin

/usr/bin/codesign --force --sign "Mac Developer" --timestamp=none ~/Library/Application\ Support/Developer/Shared/Xcode/Plug-ins/*.xcplugin
```
